### PR TITLE
Fix macOS compilation

### DIFF
--- a/Source/Blood/Private/BloodPrecomputedMaps.h
+++ b/Source/Blood/Private/BloodPrecomputedMaps.h
@@ -8,7 +8,7 @@ struct FBloodValue;
 
 namespace Blood
 {
-	using FFPropertyReadFunc = TFunctionRef<FBloodValue(const FProperty* ValueProp, const uint8* ValuePtr)>;
+	using FFPropertyReadFunc = TFunction<FBloodValue(const FProperty* ValueProp, const uint8* ValuePtr)>;
 
 	class FPrecomputedMaps
 	{

--- a/Source/HeartEditor/Private/Graph/HeartGraphAssetEditor.cpp
+++ b/Source/HeartEditor/Private/Graph/HeartGraphAssetEditor.cpp
@@ -1173,7 +1173,7 @@ namespace Heart::AssetEditor
 
 	bool FHeartGraphEditor::CanJumpToGraphNodeDefinition() const
 	{
-		if (!GetSelectedHeartGraphNodes().Num() == 1)
+		if (GetSelectedHeartGraphNodes().Num() != 1)
 		{
 			return false;
 		}
@@ -1199,7 +1199,7 @@ namespace Heart::AssetEditor
 
 	bool FHeartGraphEditor::CanJumpToNodeObjectDefinition() const
 	{
-		if (!GetSelectedHeartGraphNodes().Num() == 1)
+		if (GetSelectedHeartGraphNodes().Num() != 1)
 	    {
     		return false;
 	    }


### PR DESCRIPTION
Clang on macOS appears to be stricter in a few regards than MSVC.

`FFPropertyReadFunc` shouldn't be a function **reference** because instances are created in-place in `TReaderLambdaGen`. To ensure proper lifetime of the function, the function iself must be passed as a value.
This is corroborated by UE's documentation in `Function.h`:
> TFunctionRef\<FuncType>
> A class which represents a reference to something callable.  The important part here is *reference* - if
> you bind it to a lambda and the lambda goes out of scope, you will be left with an invalid reference.

With regards to the changes to the if statements, I think we can all agree that this shouldn't have worked in the first place.