### PR TITLE
Fix compilation on macOS

### DIFF
--- a/Source/Heart/Public/GraphRegistry/HeartGraphNodeRegistry.h
+++ b/Source/Heart/Public/GraphRegistry/HeartGraphNodeRegistry.h
@@ -101,7 +101,7 @@ public:
 	/**
 	 * Get the graph node class that we use to represent the given arbitrary class.
 	 */
-	UE_DEPRECATED(5.4, TEXT("Please use GetGraphNodeClassesForNode or another method of determining a NodeSource's graph node"))
+	UE_DEPRECATED(5.4, "Please use GetGraphNodeClassesForNode or another method of determining a NodeSource's graph node")
 	UFUNCTION(BlueprintCallable)
 	virtual TSubclassOf<UHeartGraphNode> GetGraphNodeClassForNode(const FHeartNodeSource NodeSource) const;
 

--- a/Source/Heart/Public/Model/HeartGraph.h
+++ b/Source/Heart/Public/Model/HeartGraph.h
@@ -246,14 +246,14 @@ public:
 	/**
 	 * Create a new node, spawning a new NodeObject from the NodeClass provided.
 	 */
-	UE_DEPRECATED(5.3, TEXT("Use CreateNode_Instanced instead"))
+	UE_DEPRECATED(5.3, "Use CreateNode_Instanced instead")
 	UFUNCTION(BlueprintCallable, Category = "Heart|GraphNode")
 	UHeartGraphNode* CreateNodeFromClass(const UClass* NodeClass, const FVector2D& Location);
 
 	/**
 	 * Create a new node, using the provided NodeObject
 	 */
-	UE_DEPRECATED(5.3, TEXT("Use CreateNode_Reference instead"))
+	UE_DEPRECATED(5.3, "Use CreateNode_Reference instead")
 	UFUNCTION(BlueprintCallable, Category = "Heart|GraphNode")
 	UHeartGraphNode* CreateNodeFromObject(UObject* NodeObject, const FVector2D& Location);
 

--- a/Source/Heart/Public/Model/HeartGraphUtils.h
+++ b/Source/Heart/Public/Model/HeartGraphUtils.h
@@ -22,17 +22,17 @@ namespace Heart::Utils
 {
 	using FFindNodePredicate = TDelegate<bool(const UHeartGraphNode*)>;
 
-	HEART_API UE_NODISCARD UHeartGraphNode* FindNodeOfClass(const UHeartGraph* Graph, TSubclassOf<UHeartGraphNode> Class);
+	UE_NODISCARD HEART_API UHeartGraphNode* FindNodeOfClass(const UHeartGraph* Graph, TSubclassOf<UHeartGraphNode> Class);
 
-	HEART_API UE_NODISCARD UHeartGraphNode* FindNodeByPredicate(const UHeartGraph* Graph, const FFindNodePredicate& Predicate);
+	UE_NODISCARD HEART_API UHeartGraphNode* FindNodeByPredicate(const UHeartGraph* Graph, const FFindNodePredicate& Predicate);
 
-	HEART_API UE_NODISCARD TArray<UHeartGraphNode*> FindAllNodesOfClass(const UHeartGraph* Graph, TSubclassOf<UHeartGraphNode> Class);
+	UE_NODISCARD HEART_API TArray<UHeartGraphNode*> FindAllNodesOfClass(const UHeartGraph* Graph, TSubclassOf<UHeartGraphNode> Class);
 
-	HEART_API UE_NODISCARD TArray<UHeartGraphNode*> FindAllNodesByPredicate(const UHeartGraph* Graph, const FFindNodePredicate& Predicate);
+	UE_NODISCARD HEART_API TArray<UHeartGraphNode*> FindAllNodesByPredicate(const UHeartGraph* Graph, const FFindNodePredicate& Predicate);
 
-	HEART_API UE_NODISCARD Query::FPinQueryResult FindPinsByTag(const UHeartGraphNode* Node, FHeartGraphPinTag Tag);
+	UE_NODISCARD HEART_API Query::FPinQueryResult FindPinsByTag(const UHeartGraphNode* Node, FHeartGraphPinTag Tag);
 
-	HEART_API UE_NODISCARD TOptional<FHeartGraphPinDesc> ResolvePinDesc(const UHeartGraph* Graph, const FHeartGraphPinReference& Reference);
+	UE_NODISCARD HEART_API TOptional<FHeartGraphPinDesc> ResolvePinDesc(const UHeartGraph* Graph, const FHeartGraphPinReference& Reference);
 }
 
 DECLARE_DYNAMIC_DELEGATE_RetVal_OneParam(bool, FHeartGraphNodePredicate, const UHeartGraphNode*, Node);

--- a/Source/Heart/Public/Model/HeartQueries.h
+++ b/Source/Heart/Public/Model/HeartQueries.h
@@ -284,8 +284,8 @@ namespace Heart::Query
 		FPinQueryResult& DefaultSort();
 
 	private:
-		FORCEINLINE void Internal_GetOptions(TArray<FHeartPinGuid>& Options) const;
-		FORCEINLINE const TMap<FHeartPinGuid, FHeartGraphPinDesc>& Internal_GetMap() const;
+		void Internal_GetOptions(TArray<FHeartPinGuid>& Options) const;
+		const TMap<FHeartPinGuid, FHeartGraphPinDesc>& Internal_GetMap() const;
 
 		const FHeartNodePinData& Reference;
 	};

--- a/Source/HeartCoreEditor/Public/Customizations/ItemsArrayCustomization.h
+++ b/Source/HeartCoreEditor/Public/Customizations/ItemsArrayCustomization.h
@@ -17,7 +17,7 @@ namespace Heart
         };
 
 	private:
-		friend SharedPointerInternals::TIntrusiveReferenceController;
+		friend SharedPointerInternals::TIntrusiveReferenceController<FItemsArrayCustomization, ESPMode::ThreadSafe>;
 
 		FItemsArrayCustomization(const FArgs& Args)
 		  : Customization(Args) {}


### PR DESCRIPTION
Another round of CLang strictness!

----

The `TEXT` macro prepends the `u` before a text literal, which CLang doesn't like:
```
0>HeartGraphNodeRegistry.h(104,21): Error  : 'deprecated' attribute requires a string
0>        UE_DEPRECATED(5.4, TEXT("Please use GetGraphNodeClassesForNode or another method of determining a NodeSource's graph node"))
0>                           ^
```
I checked the UE codebase, they also just use regular strings.

----

The `UE_NODISCARD` has to come _before_ the `HEART_API` to compile on macOS. My apologies, I forgot to mention that yesterday.
 
----

If you mark a function as inline (which the `FORCEINLINE` macro does), you have to define it in the header file. Otherwise, it can't be inlined because the calling code can't see the definition! I removed the `FORCEINLINE` macro, let me know if you would rather move the code to the header.

----

Finally, CLang requires you to specify the template arguments of friend classes. No inference or generic matching allowed, so I figured out the right template arguments to use!
