### PR TITLE
Made UHeartInputLinkerBase::InputCallbackMappings an UPROPERTY

### DIFF
--- a/Source/HeartCanvas/Private/UMG/HeartGraphWidgetBase.cpp
+++ b/Source/HeartCanvas/Private/UMG/HeartGraphWidgetBase.cpp
@@ -25,5 +25,5 @@ const FText UHeartGraphWidgetBase::GetPaletteCategory()
 UHeartInputLinkerBase* UHeartGraphWidgetBase::ResolveLinker_Implementation() const
 {
 	// Assume that something up our parent chain will be able to handle this.
-	return Heart::Input::TLinkerType<UWidget>::FindLinker(GetTypedOuter<UWidget>());
+	return THeartInputLinkerType<UWidget>::FindLinker(GetTypedOuter<UWidget>());
 }

--- a/Source/HeartCanvas/Public/Input/HeartCanvasInputHandler_DDO_Action.h
+++ b/Source/HeartCanvas/Public/Input/HeartCanvasInputHandler_DDO_Action.h
@@ -55,7 +55,7 @@ class HEARTCANVAS_API UHeartCanvasInputHandler_DDO_Action : public UHeartInputHa
 	GENERATED_BODY()
 
 protected:
-	virtual Heart::Input::EExecutionOrder GetExecutionOrder() const override { return Heart::Input::Deferred; }
+	virtual EHeartInputExecutionOrder GetExecutionOrder() const override { return EHeartInputExecutionOrder::Deferred; }
 	virtual bool PassCondition(const UObject* TestTarget) const override;
 	virtual FHeartEvent OnTriggered(UObject* Target, const FHeartInputActivation& Activation) const override;
 

--- a/Source/HeartCanvas/Public/Input/HeartCanvasInputHandler_HeartDDO.h
+++ b/Source/HeartCanvas/Public/Input/HeartCanvasInputHandler_HeartDDO.h
@@ -17,7 +17,7 @@ class HEARTCANVAS_API UHeartCanvasInputHandler_HeartDDO : public UHeartInputHand
 	GENERATED_BODY()
 
 protected:
-	virtual Heart::Input::EExecutionOrder GetExecutionOrder() const override { return Heart::Input::Deferred; }
+	virtual EHeartInputExecutionOrder GetExecutionOrder() const override { return EHeartInputExecutionOrder::Deferred; }
 	virtual bool PassCondition(const UObject* TestTarget) const override;
 	virtual FHeartEvent OnTriggered(UObject* Target, const FHeartInputActivation& Activation) const override;
 

--- a/Source/HeartCanvas/Public/Input/HeartSlateInputLinker.h
+++ b/Source/HeartCanvas/Public/Input/HeartSlateInputLinker.h
@@ -28,22 +28,19 @@ public:
 	virtual void HandleOnDragLeave(const TSharedRef<SWidget>& Widget, const FDragDropEvent& DragDropEvent);
 };
 
-namespace Heart::Input
+template <>
+struct THeartInputLinkerType<SWidget>
 {
-	template <>
-	struct TLinkerType<SWidget>
-	{
-		static constexpr bool Supported = true;
+	static constexpr bool Supported = true;
 
-		using FReplyType = FReply;
-		using FValueType = const TSharedRef<SWidget>&;
-		using FDDOType = FReply;
+	using FReplyType = FReply;
+	using FValueType = const TSharedRef<SWidget>&;
+	using FDDOType = FReply;
 
-		static FReplyType NoReply() { return FReply::Unhandled(); }
+	static FReplyType NoReply() { return FReply::Unhandled(); }
 
-		HEARTCANVAS_API static UHeartSlateInputLinker* FindLinker(const TSharedRef<SWidget>& Widget);
-	};
-}
+	HEARTCANVAS_API static UHeartSlateInputLinker* FindLinker(const TSharedRef<SWidget>& Widget);
+};
 
 /**
  * Place this macro after the SLATE_END_ARGS or Construct of a SWidget derived class you wish to implement an InputLinker on.

--- a/Source/HeartCanvas/Public/Input/HeartWidgetInputLinker.h
+++ b/Source/HeartCanvas/Public/Input/HeartWidgetInputLinker.h
@@ -36,22 +36,19 @@ public:
 	virtual void HandleOnDragCancelled(UWidget* Widget, const FDragDropEvent& DragDropEvent, UDragDropOperation* InOperation);
 };
 
-namespace Heart::Input
+template <>
+struct THeartInputLinkerType<UWidget>
 {
-	template <>
-	struct TLinkerType<UWidget>
-	{
-		static constexpr bool Supported = true;
+	static constexpr bool Supported = true;
 
-		using FReplyType = FReply;
-		using FValueType = UWidget*;
-		using FDDOType = UDragDropOperation*;
+	using FReplyType = FReply;
+	using FValueType = UWidget*;
+	using FDDOType = UDragDropOperation*;
 
-		static FReplyType NoReply() { return FReply::Unhandled(); }
+	static FReplyType NoReply() { return FReply::Unhandled(); }
 
-		HEARTCANVAS_API static UHeartWidgetInputLinker* FindLinker(const UWidget* Widget);
-	};
-}
+	HEARTCANVAS_API static UHeartWidgetInputLinker* FindLinker(const UWidget* Widget);
+};
 
 /**
  * Place this macro after the GENERATED_BODY or constructor of a UWidget derived class you wish to implement an InputLinker on.

--- a/Source/HeartCore/Private/Input/HeartInputTrigger.cpp
+++ b/Source/HeartCore/Private/Input/HeartInputTrigger.cpp
@@ -4,9 +4,9 @@
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(HeartInputTrigger)
 
-TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyDown::CreateTrips() const
+TArray<FHeartInputTrip> FHeartInputTrigger_KeyDown::CreateTrips() const
 {
-	TArray<Heart::Input::FInputTrip> Trips;
+	TArray<FHeartInputTrip> Trips;
 
 	for (const FKey& TripKey : Keys)
 	{
@@ -16,9 +16,9 @@ TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyDown::CreateTrips() const
 	return Trips;
 }
 
-TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyDownMod::CreateTrips() const
+TArray<FHeartInputTrip> FHeartInputTrigger_KeyDownMod::CreateTrips() const
 {
-	TArray<Heart::Input::FInputTrip> Trips;
+	TArray<FHeartInputTrip> Trips;
 
 	for (const auto& TripKey : Keys)
 	{
@@ -28,9 +28,9 @@ TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyDownMod::CreateTrips() co
 	return Trips;
 }
 
-TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyUp::CreateTrips() const
+TArray<FHeartInputTrip> FHeartInputTrigger_KeyUp::CreateTrips() const
 {
-	TArray<Heart::Input::FInputTrip> Trips;
+	TArray<FHeartInputTrip> Trips;
 
 	for (const FKey& TripKey : Keys)
 	{
@@ -40,9 +40,9 @@ TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyUp::CreateTrips() const
 	return Trips;
 }
 
-TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyUpMod::CreateTrips() const
+TArray<FHeartInputTrip> FHeartInputTrigger_KeyUpMod::CreateTrips() const
 {
-	TArray<Heart::Input::FInputTrip> Trips;
+	TArray<FHeartInputTrip> Trips;
 
 	for (const auto& TripKey : Keys)
 	{
@@ -52,9 +52,9 @@ TArray<Heart::Input::FInputTrip> FHeartInputTrigger_KeyUpMod::CreateTrips() cons
 	return Trips;
 }
 
-TArray<Heart::Input::FInputTrip> FHeartInputTrigger_Manual::CreateTrips() const
+TArray<FHeartInputTrip> FHeartInputTrigger_Manual::CreateTrips() const
 {
-	TArray<Heart::Input::FInputTrip> Trips;
+	TArray<FHeartInputTrip> Trips;
 
 	for (const FName TripKey : Keys)
 	{

--- a/Source/HeartCore/Public/Input/HeartInputHandlerAssetBase.h
+++ b/Source/HeartCore/Public/Input/HeartInputHandlerAssetBase.h
@@ -29,8 +29,8 @@ public:
 		return true;
 	}
 
-	virtual Heart::Input::EExecutionOrder GetExecutionOrder() const
-		PURE_VIRTUAL(UHeartInputHandlerAssetBase::GetExecutionOrder, return Heart::Input::None; )
+	virtual EHeartInputExecutionOrder GetExecutionOrder() const
+		PURE_VIRTUAL(UHeartInputHandlerAssetBase::GetExecutionOrder, return EHeartInputExecutionOrder::None; )
 
 	virtual FHeartEvent OnTriggered(UObject* Target, const FHeartInputActivation& Activation) const
 		PURE_VIRTUAL(UHeartInputHandlerAssetBase::OnTriggered, return FHeartEvent::Invalid; )

--- a/Source/HeartCore/Public/Input/HeartInputHandler_Immediate.h
+++ b/Source/HeartCore/Public/Input/HeartInputHandler_Immediate.h
@@ -15,9 +15,9 @@ class HEARTCORE_API UHeartInputHandler_Immediate : public UHeartInputHandlerAsse
 	GENERATED_BODY()
 
 public:
-	virtual Heart::Input::EExecutionOrder GetExecutionOrder() const override
+	virtual EHeartInputExecutionOrder GetExecutionOrder() const override
 	{
-		return HandleInput ? Heart::Input::Event : Heart::Input::Listener;
+		return HandleInput ? EHeartInputExecutionOrder::Event : EHeartInputExecutionOrder::Listener;
 	}
 
 protected:

--- a/Source/HeartCore/Public/Input/HeartInputLinkerBase.h
+++ b/Source/HeartCore/Public/Input/HeartInputLinkerBase.h
@@ -28,14 +28,14 @@ namespace Heart::Input
 	class HEARTCORE_API FCallbackQuery
 	{
 	public:
-		FCallbackQuery(const UHeartInputLinkerBase* Linker, const FInputTrip& Trip);
+		FCallbackQuery(const UHeartInputLinkerBase* Linker, const FHeartInputTrip& Trip);
 
 		FCallbackQuery& Sort();
 
-		FCallbackQuery& ForEachWithBreak(const UObject* Target, const TFunctionRef<bool(const FSortableCallback&)>& Predicate);
+		FCallbackQuery& ForEachWithBreak(const UObject* Target, const TFunctionRef<bool(const FHeartSortableInputCallback&)>& Predicate);
 
 	private:
-		TArray<const FSortableCallback*> Callbacks;
+		TArray<FHeartSortableInputCallback> Callbacks;
 	};
 }
 
@@ -47,17 +47,17 @@ class HEARTCORE_API UHeartInputLinkerBase : public UObject
 	friend Heart::Input::FCallbackQuery;
 
 protected:
-	FHeartEvent QuickTryCallbacks(const Heart::Input::FInputTrip& Trip, UObject* Target, const FHeartInputActivation& Activation);
+	FHeartEvent QuickTryCallbacks(const FHeartInputTrip& Trip, UObject* Target, const FHeartInputActivation& Activation);
 
 public:
-	void BindInputCallback(const Heart::Input::FInputTrip& Trip, const Heart::Input::FSortableCallback& InputCallback);
-	void UnbindInputCallback(const Heart::Input::FInputTrip& Trip);
+	void BindInputCallback(const FHeartInputTrip& Trip, const FHeartSortableInputCallback& InputCallback);
+	void UnbindInputCallback(const FHeartInputTrip& Trip);
 
 	// Custom input
 	virtual FHeartEvent HandleManualInput(UObject* Target, FName Key, const FHeartManualEvent& Activation);
 	TArray<FHeartManualInputQueryResult> QueryManualTriggers(const UObject* Target) const;
 
-	Heart::Input::FCallbackQuery Query(const Heart::Input::FInputTrip& Trip) const;
+	Heart::Input::FCallbackQuery Query(const FHeartInputTrip& Trip) const;
 
 	UFUNCTION(BlueprintCallable, Category = "Heart|InputLinker")
 	void AddBindings(const TArray<FHeartBoundInput>& Bindings);
@@ -67,18 +67,19 @@ public:
 
 protected:
 	// Input trips that fire a delegate.
-	TMultiMap<Heart::Input::FInputTrip, const Heart::Input::FSortableCallback> InputCallbackMappings;
+	UPROPERTY()
+	TMap<FHeartInputTrip, FHeartSortableCallbackList> InputCallbackMappings;
 };
 
 namespace Heart::Input
 {
 	template <
 		typename TTarget
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static typename TLinkerType<TTarget>::FReplyType LinkOnMouseWheel(typename TLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+	static typename THeartInputLinkerType<TTarget>::FReplyType LinkOnMouseWheel(typename THeartInputLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			auto BindingReply = Linker->HandleOnMouseWheel(Target, InGeometry, InMouseEvent);
 
@@ -88,16 +89,16 @@ namespace Heart::Input
 			}
 		}
 
-		return TLinkerType<TTarget>::NoReply();
+		return THeartInputLinkerType<TTarget>::NoReply();
 	}
 
 	template <
 		typename TTarget
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static typename TLinkerType<TTarget>::FReplyType LinkOnMouseButtonDown(typename TLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+	static typename THeartInputLinkerType<TTarget>::FReplyType LinkOnMouseButtonDown(typename THeartInputLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			auto BindingReply = Linker->HandleOnMouseButtonDown(Target, InGeometry, InMouseEvent);
 
@@ -107,16 +108,16 @@ namespace Heart::Input
 			}
 		}
 
-		return TLinkerType<TTarget>::NoReply();
+		return THeartInputLinkerType<TTarget>::NoReply();
 	}
 
 	template <
 		typename TTarget
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static typename TLinkerType<TTarget>::FReplyType LinkOnMouseButtonUp(typename TLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+	static typename THeartInputLinkerType<TTarget>::FReplyType LinkOnMouseButtonUp(typename THeartInputLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			auto BindingReply = Linker->HandleOnMouseButtonUp(Target, InGeometry, InMouseEvent);
 
@@ -126,30 +127,30 @@ namespace Heart::Input
 			}
 		}
 
-		return TLinkerType<TTarget>::NoReply();
+		return THeartInputLinkerType<TTarget>::NoReply();
 	}
 
 	template <
 		typename TTarget
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static typename TLinkerType<TTarget>::FReplyType LinkOnKeyDown(typename TLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
+	static typename THeartInputLinkerType<TTarget>::FReplyType LinkOnKeyDown(typename THeartInputLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			return Linker->HandleOnKeyDown(Target, InGeometry, InKeyEvent);
 		}
 
-		return TLinkerType<TTarget>::NoReply();
+		return THeartInputLinkerType<TTarget>::NoReply();
 	}
 
 	template <
 		typename TTarget
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static typename TLinkerType<TTarget>::FReplyType LinkOnKeyUp(typename TLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
+	static typename THeartInputLinkerType<TTarget>::FReplyType LinkOnKeyUp(typename THeartInputLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			auto BindingReply = Linker->HandleOnKeyUp(Target, InGeometry, InKeyEvent);
 
@@ -159,23 +160,23 @@ namespace Heart::Input
 			}
 		}
 
-		return TLinkerType<TTarget>::NoReply();
+		return THeartInputLinkerType<TTarget>::NoReply();
 	}
 
 	template <
 		typename TTarget
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static typename TLinkerType<TTarget>::FDDOType LinkOnDragDetected(typename TLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
+	static typename THeartInputLinkerType<TTarget>::FDDOType LinkOnDragDetected(typename THeartInputLinkerType<TTarget>::FValueType Target, const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			return Linker->HandleOnDragDetected(Target, InGeometry, InMouseEvent);
 		}
 
-		if constexpr (std::is_same_v<typename TLinkerType<TTarget>::FDDOType, FReply>)
+		if constexpr (std::is_same_v<typename THeartInputLinkerType<TTarget>::FDDOType, FReply>)
 		{
-			return TLinkerType<TTarget>::NoReply();
+			return THeartInputLinkerType<TTarget>::NoReply();
 		}
 		else return {};
 	}
@@ -184,18 +185,18 @@ namespace Heart::Input
 		typename TTarget,
 		typename TRetVal,
 		typename... TArgs
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static TRetVal LinkOnDrop(typename TLinkerType<TTarget>::FValueType Target, TArgs... Args)
+	static TRetVal LinkOnDrop(typename THeartInputLinkerType<TTarget>::FValueType Target, TArgs... Args)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			return Linker->HandleOnDrop(Target, Args...);
 		}
 
-		if constexpr (std::is_same_v<typename TLinkerType<TTarget>::FDDOType, FReply>)
+		if constexpr (std::is_same_v<typename THeartInputLinkerType<TTarget>::FDDOType, FReply>)
 		{
-			return TLinkerType<TTarget>::NoReply();
+			return THeartInputLinkerType<TTarget>::NoReply();
 		}
 		else return {};
 	}
@@ -204,18 +205,18 @@ namespace Heart::Input
 		typename TTarget,
 		typename TRetVal,
 		typename... TArgs
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static TRetVal LinkOnDragOver(typename TLinkerType<TTarget>::FValueType Target, TArgs... Args)
+	static TRetVal LinkOnDragOver(typename THeartInputLinkerType<TTarget>::FValueType Target, TArgs... Args)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			return Linker->HandleOnDragOver(Target, Args...);
 		}
 
-		if constexpr (std::is_same_v<typename TLinkerType<TTarget>::FDDOType, FReply>)
+		if constexpr (std::is_same_v<typename THeartInputLinkerType<TTarget>::FDDOType, FReply>)
 		{
-			return TLinkerType<TTarget>::NoReply();
+			return THeartInputLinkerType<TTarget>::NoReply();
 		}
 		else return {};
 	}
@@ -223,11 +224,11 @@ namespace Heart::Input
 	template <
 		typename TTarget,
 		typename... TArgs
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static void LinkOnDragEnter(typename TLinkerType<TTarget>::FValueType Target, TArgs... Args)
+	static void LinkOnDragEnter(typename THeartInputLinkerType<TTarget>::FValueType Target, TArgs... Args)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			Linker->HandleOnDragEnter(Target, Args...);
 		}
@@ -236,11 +237,11 @@ namespace Heart::Input
 	template <
 		typename TTarget,
 		typename... TArgs
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static void LinkOnDragLeave(typename TLinkerType<TTarget>::FValueType Target, TArgs... Args)
+	static void LinkOnDragLeave(typename THeartInputLinkerType<TTarget>::FValueType Target, TArgs... Args)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			Linker->HandleOnDragLeave(Target, Args...);
 		}
@@ -249,11 +250,11 @@ namespace Heart::Input
 	template <
 		typename TTarget,
 		typename... TArgs
-		UE_REQUIRES(TLinkerType<TTarget>::Supported)
+		UE_REQUIRES(THeartInputLinkerType<TTarget>::Supported)
 	>
-	static void LinkOnDragCancelled(typename TLinkerType<TTarget>::FValueType Target, TArgs... Args)
+	static void LinkOnDragCancelled(typename THeartInputLinkerType<TTarget>::FValueType Target, TArgs... Args)
 	{
-		if (auto&& Linker = TLinkerType<TTarget>::FindLinker(Target))
+		if (auto&& Linker = THeartInputLinkerType<TTarget>::FindLinker(Target))
 		{
 			Linker->HandleOnDragCancelled(Target, Args...);
 		}

--- a/Source/HeartCore/Public/Input/HeartInputTrigger.h
+++ b/Source/HeartCore/Public/Input/HeartInputTrigger.h
@@ -13,7 +13,7 @@ struct HEARTCORE_API FHeartInputTrigger
 
 	virtual ~FHeartInputTrigger() {}
 
-	virtual TArray<Heart::Input::FInputTrip> CreateTrips() const { return TArray<Heart::Input::FInputTrip>(); }
+	virtual TArray<FHeartInputTrip> CreateTrips() const { return TArray<FHeartInputTrip>(); }
 };
 
 USTRUCT(BlueprintType, meta = (DisplayName = "Key Down"))
@@ -21,7 +21,7 @@ struct HEARTCORE_API FHeartInputTrigger_KeyDown : public FHeartInputTrigger
 {
 	GENERATED_BODY()
 
-	virtual TArray<Heart::Input::FInputTrip> CreateTrips() const override;
+	virtual TArray<FHeartInputTrip> CreateTrips() const override;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "KeyDown")
 	TSet<FKey> Keys;
@@ -53,7 +53,7 @@ struct HEARTCORE_API FHeartInputTrigger_KeyDownMod : public FHeartInputTrigger
 {
 	GENERATED_BODY()
 
-	virtual TArray<Heart::Input::FInputTrip> CreateTrips() const override;
+	virtual TArray<FHeartInputTrip> CreateTrips() const override;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "KeyDown")
 	TArray<FHeartKeyAndModifiers> Keys;
@@ -64,7 +64,7 @@ struct HEARTCORE_API FHeartInputTrigger_KeyUp : public FHeartInputTrigger
 {
 	GENERATED_BODY()
 
-	virtual TArray<Heart::Input::FInputTrip> CreateTrips() const override;
+	virtual TArray<FHeartInputTrip> CreateTrips() const override;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "KeyUp")
 	TSet<FKey> Keys;
@@ -75,7 +75,7 @@ struct HEARTCORE_API FHeartInputTrigger_KeyUpMod : public FHeartInputTrigger
 {
 	GENERATED_BODY()
 
-	virtual TArray<Heart::Input::FInputTrip> CreateTrips() const override;
+	virtual TArray<FHeartInputTrip> CreateTrips() const override;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "KeyUp")
 	TArray<FHeartKeyAndModifiers> Keys;
@@ -86,7 +86,7 @@ struct HEARTCORE_API FHeartInputTrigger_Manual : public FHeartInputTrigger
 {
 	GENERATED_BODY()
 
-	virtual TArray<Heart::Input::FInputTrip> CreateTrips() const override;
+	virtual TArray<FHeartInputTrip> CreateTrips() const override;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Manual")
 	TSet<FName> Keys;

--- a/Source/HeartCore/Public/Input/HeartInputTrip.h
+++ b/Source/HeartCore/Public/Input/HeartInputTrip.h
@@ -4,6 +4,7 @@
 
 #include "InputCoreTypes.h"
 #include "GameFramework/PlayerInput.h"
+#include "HeartInputTrip.generated.h"
 
 namespace Heart::Input
 {
@@ -48,69 +49,74 @@ namespace Heart::Input
 
 		return ModifierMask;
 	}
+}
 
-	struct FInputTrip
+USTRUCT()
+struct FHeartInputTrip
+{
+	GENERATED_BODY()
+
+	FHeartInputTrip() {}
+
+	FHeartInputTrip(const FKey& Key, const bool IsControlDown, const bool IsAltDown, const bool IsShiftDown, const bool IsCommandDown, const Heart::Input::ETripType Type)
+	  : Type(Type),
+		Key(Key),
+		ModifierMask(EModifierKey::FromBools(IsControlDown, IsAltDown, IsShiftDown, IsCommandDown))
+	{}
+
+	FHeartInputTrip(const FKeyEvent& KeyEvent, const Heart::Input::ETripType Type)
+	  : Type(Type),
+		Key(KeyEvent.GetKey()),
+		ModifierMask(EModifierKey::FromBools(KeyEvent.IsControlDown(), KeyEvent.IsAltDown(), KeyEvent.IsShiftDown(), KeyEvent.IsCommandDown()))
+	{}
+
+	FHeartInputTrip(const FPointerEvent& PointerEvent, const Heart::Input::ETripType Type)
+	  :	Type(Type),
+		Key(PointerEvent.GetEffectingButton().IsValid() ? PointerEvent.GetEffectingButton() : *PointerEvent.GetPressedButtons().CreateConstIterator()),
+		ModifierMask(EModifierKey::FromBools(PointerEvent.IsControlDown(), PointerEvent.IsAltDown(), PointerEvent.IsShiftDown(), PointerEvent.IsCommandDown()))
+	{}
+
+	FHeartInputTrip(const FInputKeyParams& Params)
+	  : Type(Heart::Input::InputEventToTripType(Params.Event)),
+		Key(Params.Key),
+		ModifierMask(Heart::Input::ModifierKeysFromState(FSlateApplication::Get().GetModifierKeys()))
+	{}
+
+	FHeartInputTrip(const FName& ManualEvent)
+	  : Type(Heart::Input::Manual),
+		CustomKey(ManualEvent)
+	{}
+
+	Heart::Input::ETripType Type = Heart::Input::Unknown;
+	FKey Key = EKeys::Invalid;
+	uint8 ModifierMask = 0;
+	FName CustomKey = NAME_None;
+
+	bool IsValid() const
 	{
-		FInputTrip(const FKey& Key, const bool IsControlDown, const bool IsAltDown, const bool IsShiftDown, const bool IsCommandDown, const ETripType Type)
-		  : Type(Type),
-			Key(Key),
-			ModifierMask(EModifierKey::FromBools(IsControlDown, IsAltDown, IsShiftDown, IsCommandDown))
-		{}
-
-		FInputTrip(const FKeyEvent& KeyEvent, const ETripType Type)
-		  : Type(Type),
-			Key(KeyEvent.GetKey()),
-			ModifierMask(EModifierKey::FromBools(KeyEvent.IsControlDown(), KeyEvent.IsAltDown(), KeyEvent.IsShiftDown(), KeyEvent.IsCommandDown()))
-		{}
-
-		FInputTrip(const FPointerEvent& PointerEvent, const ETripType Type)
-		  :	Type(Type),
-			Key(PointerEvent.GetEffectingButton().IsValid() ? PointerEvent.GetEffectingButton() : *PointerEvent.GetPressedButtons().CreateConstIterator()),
-			ModifierMask(EModifierKey::FromBools(PointerEvent.IsControlDown(), PointerEvent.IsAltDown(), PointerEvent.IsShiftDown(), PointerEvent.IsCommandDown()))
-		{}
-
-		FInputTrip(const FInputKeyParams& Params)
-		  : Type(InputEventToTripType(Params.Event)),
-		    Key(Params.Key),
-		    ModifierMask(ModifierKeysFromState(FSlateApplication::Get().GetModifierKeys()))
-		{}
-
-		FInputTrip(const FName& ManualEvent)
-		  : Type(Manual),
-			CustomKey(ManualEvent)
-		{}
-
-		const ETripType Type = Unknown;
-		const FKey Key = EKeys::Invalid;
-		const uint8 ModifierMask = 0;
-		const FName CustomKey = NAME_None;
-
-		bool IsValid() const
-		{
-			return Type != Unknown && (Key.IsValid() || !CustomKey.IsNone());
-		}
-
-		friend bool operator==(const FInputTrip& Lhs, const FInputTrip& Rhs)
-		{
-			return Lhs.Type == Rhs.Type &&
-				   Lhs.Key == Rhs.Key &&
-				   Lhs.ModifierMask == Rhs.ModifierMask &&
-				   Lhs.CustomKey == Rhs.CustomKey;
-		}
-
-		friend bool operator!=(const FInputTrip& Lhs, const FInputTrip& Rhs)
-		{
-			return !(Lhs == Rhs);
-		}
-	};
-
-	FORCEINLINE uint32 GetTypeHash(const FInputTrip& Trip)
-	{
-		uint32 KeyHash = 0;
-		KeyHash = HashCombine(KeyHash, ::GetTypeHash(Trip.Type));
-		KeyHash = HashCombine(KeyHash, GetTypeHash(Trip.Key));
-		KeyHash = HashCombine(KeyHash, ::GetTypeHash(Trip.ModifierMask));
-		KeyHash = HashCombine(KeyHash, GetTypeHash(Trip.CustomKey));
-		return KeyHash;
+		return Type != Heart::Input::Unknown && (Key.IsValid() || !CustomKey.IsNone());
 	}
+
+	friend bool operator==(const FHeartInputTrip& Lhs, const FHeartInputTrip& Rhs)
+	{
+		return Lhs.Type == Rhs.Type &&
+			   Lhs.Key == Rhs.Key &&
+			   Lhs.ModifierMask == Rhs.ModifierMask &&
+			   Lhs.CustomKey == Rhs.CustomKey;
+	}
+
+	friend bool operator!=(const FHeartInputTrip& Lhs, const FHeartInputTrip& Rhs)
+	{
+		return !(Lhs == Rhs);
+	}
+};
+
+FORCEINLINE uint32 GetTypeHash(const FHeartInputTrip& Trip)
+{
+	uint32 KeyHash = 0;
+	KeyHash = HashCombine(KeyHash, ::GetTypeHash(Trip.Type));
+	KeyHash = HashCombine(KeyHash, GetTypeHash(Trip.Key));
+	KeyHash = HashCombine(KeyHash, ::GetTypeHash(Trip.ModifierMask));
+	KeyHash = HashCombine(KeyHash, GetTypeHash(Trip.CustomKey));
+	return KeyHash;
 }

--- a/Source/HeartCore/Public/Input/HeartInputTypes.h
+++ b/Source/HeartCore/Public/Input/HeartInputTypes.h
@@ -2,40 +2,46 @@
 
 #pragma once
 
+#include "HeartInputTypes.generated.h"
+
 struct FHeartEvent;
 struct FHeartInputActivation;
 
 class UHeartInputHandlerAssetBase;
 
-namespace Heart::Input
+template <typename T>
+struct THeartInputLinkerType
 {
-	template <typename T>
-	struct TLinkerType
-	{
-		static constexpr bool Supported = false;
-	};
+	static constexpr bool Supported = false;
+};
 
-	enum EExecutionOrder
-	{
-		None, // Blank layer. Do not use.
-		Event, // Default layer. Handlers can capture input or bubble it.
-		Deferred, // Layer for events that handle event at the moment, but continue to have effects for multiple frames.
-		Listener, // Interception layer. Handlers can intercept, but cannot stop it from bubbling.
+enum class EHeartInputExecutionOrder
+{
+	None, // Blank layer. Do not use.
+	Event, // Default layer. Handlers can capture input or bubble it.
+	Deferred, // Layer for events that handle event at the moment, but continue to have effects for multiple frames.
+	Listener, // Interception layer. Handlers can intercept, but cannot stop it from bubbling.
 
-		HighestHandlingPriority = Deferred
-	};
+	HighestHandlingPriority = Deferred
+};
 
-	struct FSortableCallback
-	{
-		TObjectPtr<const UHeartInputHandlerAssetBase> Handler;
+USTRUCT()
+struct FHeartSortableInputCallback
+{
+	GENERATED_BODY()
+	
+	UPROPERTY()
+	TObjectPtr<const UHeartInputHandlerAssetBase> Handler;
 
-		// Determines the order that callback handler runs in, and whether they bubble the input callstack
-		const EExecutionOrder Priority = None;
+	// Determines the order that callback handler runs in, and whether they bubble the input callstack
+	EHeartInputExecutionOrder Priority = EHeartInputExecutionOrder::None;
+};
 
-		friend bool operator<(const FSortableCallback& A, const FSortableCallback& B)
-		{
-			// Sort in reverse. Higher priorities should be ordered first, lower after.
-			return A.Priority > B.Priority;
-		}
-	};
-}
+USTRUCT()
+struct FHeartSortableCallbackList
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	TArray<FHeartSortableInputCallback> Callbacks;
+};

--- a/Source/HeartScene/Private/Input/HeartSceneInputLinker.cpp
+++ b/Source/HeartScene/Private/Input/HeartSceneInputLinker.cpp
@@ -8,5 +8,5 @@
 
 bool UHeartSceneInputLinker::InputKey(const FInputKeyParams& Params, UObject* Target)
 {
-	return QuickTryCallbacks(Heart::Input::FInputTrip(Params), Target, FHeartInputActivation(Params)).WasEventCaptured();
+	return QuickTryCallbacks(FHeartInputTrip(Params), Target, FHeartInputActivation(Params)).WasEventCaptured();
 }


### PR DESCRIPTION
This PR replaces the MultiMap `UHeartInputLinkerBase::InputCallbackMappings` with an `UPROPERTY` Map.

# Rationale

This is required to keep the input handlers wrapped in the `FSortableCallback` alive, otherwise the following code will eventually result in a segfault due to `Handler` being garbage collected:

```c++
// create action
auto* Handler = NewObject<UHeartInputHandler_Action>();
Handler->SetAction(USelectNodeAction::StaticClass());

FHeartInputTrigger_KeyDownMod Trigger;
// [...]

FHeartBoundInput Input;
Input.InputHandler = Handler;
Input.Triggers.Add(FInstancedStruct::Make(Trigger));

InputLinker->AddBindings({ Input });
```

The above code should work without requiring the caller to keep a reference to the input handler object around to avoid GC. Ownership is transferred to the input linker, whose job it should be to keep them alive. Asking the caller to keep them alive is unintuitive and also very inconvenient.

# Implementation

To achieve this, I had to turn `Heart::Input::FInputTrip` and `Heart::Input::FSortableCallback` into `USTRUCT`s, which in turn required moving them out of the namespace. I have renamed these structs appropriately to indicate that they belong to Heart. I also had to create a wrapper struct `FHeartSortableCallbackList` that contains an `UPROPERTY` array of `FHeartSortableCallback`, as `TArray` can't be used as the value of `UPROPERTY` `TMap`s.

I also changed `Heart::Input::EExecutionOrder` to an enum **class** `EHeartInputExecutionOrder` in order not to pollute the global namespace with its very generic enum names like `None`. 